### PR TITLE
2- Added JWT retrieval and refresh

### DIFF
--- a/atunda/api/tests/auth_tests.py
+++ b/atunda/api/tests/auth_tests.py
@@ -1,0 +1,29 @@
+from rest_framework import status
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+import json
+
+client = Client()
+
+class RetrieveJWTTest(TestCase):
+    
+    def setUp(self):
+        self.testUser = {
+            'username': 'testuser',
+            'password': 'testing'
+        }
+
+
+    def test_login(self):
+        user = User.objects.create_user(username=self.testUser['username'], password=self.testUser['password'])
+        
+        response = client.post(
+            reverse('retrieve_jwt'),
+            data = json.dumps(self.testUser),
+            content_type='application/json'
+        )
+        print(response)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/atunda/api/tests/test_views.py
+++ b/atunda/api/tests/test_views.py
@@ -40,6 +40,40 @@ class CreateUserTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_login(self):
+        user = User.objects.create_user(username=self.testUser['username'], password=self.testUser['password'])
+        
+        response = client.post(
+            reverse('token_obtain_pair'),
+            data = json.dumps(self.testUser),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+    
+    def test_refresh(self):
+        user = User.objects.create_user(username=self.testUser['username'], password=self.testUser['password'])
+        
+        response = client.post(
+            reverse('token_obtain_pair'),
+            data = json.dumps(self.testUser),
+            content_type='application/json'
+        )
+        
+        response_refresh_data = {"refresh": response.data['refresh']}
+        response_refresh = client.post(
+            reverse('token_refresh'),
+            data = json.dumps(response_refresh_data),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response_refresh.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+
+
+
 # class FileUploadTestCase(TestCase):
 #     def setUp(self):
 #         self.client = APIClient()

--- a/atunda/atunda/urls.py
+++ b/atunda/atunda/urls.py
@@ -16,8 +16,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('api.urls'))
+    path('api/', include('api.urls')),
+    path('api-token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api-token/refresh', TokenRefreshView.as_view(), name='token_refresh')
 ]


### PR DESCRIPTION
Added the URL routes for simple_jwt module. When making a post request to api-token/ endpoint with a valid username and password, an access token and a refresh token will be sent back. When making a post request to api-token/refresh with a valid refresh token, a new access token will be sent back. 

I also wrote test cases for these features. 